### PR TITLE
Hotfix: slack env랑 cron 삭제

### DIFF
--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -72,4 +72,18 @@ export class ReservationController {
       times,
     );
   }
+
+  @Put()
+  @ApiOperation({ description: '예약 시작, 중지' })
+  @ApiHeader({
+    name: 'state',
+    description: '예약 활성화 상태입니다. (open = 시작, close = 중지)',
+  })
+  async reservationStart(@Query('state') state: string) {
+    
+    if (state === 'open') 
+      await this.reservationService.openReservation();
+
+    throw new BadRequestException('예약은 현재 open만 가능합니다.');
+  }
 }

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Patch,
+  Post,
   Put,
   Query,
   UseGuards,
@@ -73,16 +74,14 @@ export class ReservationController {
     );
   }
 
-  @Put()
+  @Post()
   @ApiOperation({ description: '예약 시작, 중지' })
   @ApiHeader({
     name: 'state',
     description: '예약 활성화 상태입니다. (open = 시작, close = 중지)',
   })
   async reservationStart(@Query('state') state: string) {
-    
-    if (state === 'open') 
-      await this.reservationService.openReservation();
+    if (state === 'open') await this.reservationService.openReservation();
 
     throw new BadRequestException('예약은 현재 open만 가능합니다.');
   }

--- a/src/reservation/reservation.service.ts
+++ b/src/reservation/reservation.service.ts
@@ -10,7 +10,6 @@ import { Xe_Reservation_PreEntity } from 'src/entites/xe_reservation_pre.entity'
 import { Like, Repository } from 'typeorm';
 import { ReservationSlotBuilder } from './reservation-slot.builder';
 import dayjs from 'dayjs';
-import { Cron } from '@nestjs/schedule';
 import { ReservationTransaction } from './reservation-transaction';
 import { ReservationConfigService } from './reservation-setting.service';
 
@@ -67,7 +66,6 @@ export class ReservationService {
     await this.configSvc.setPreReservationCloseSettings();
   }
 
-  @Cron('0 0 0 1 * *')
   async openReservation() {
     const list = await this.reservationRepository.find({
       where: { date: Like(`${this.nextMonth.format('YYYY-MM')}%`) },


### PR DESCRIPTION
cron 삭제한 이유는 lambda에서 cron을 제공하지 않음!!

그래서 임시방편으로 삭제하고 외부에서 적절한 시간에 api 콜 하도록 수정

api call은 aws event bridge를 사용