### PR TITLE
도커 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:18
-
-COPY package*.json ./
-
-RUN npm install
-
-COPY . .
-
-EXPOSE 3000
-
-CMD ["dist/serverless.handler"]
-
-# # DEVELOPMENT
-# FROM amazon/aws-lambda-nodejs:18 As development
-# WORKDIR /usr/src/app
+# FROM public.ecr.aws/lambda/nodejs:18
 
 # COPY package*.json ./
 
@@ -20,23 +6,37 @@ CMD ["dist/serverless.handler"]
 
 # COPY . .
 
-# RUN npm run build
-
-
-
-# # PRODUCTION
-# FROM amazon/aws-lambda-nodejs:18 As production
-
-# WORKDIR /usr/src/app
-
-# COPY package*.json ./
-
-# RUN npm ci --only=production
-
-# COPY . .
-
-# COPY --from=development /usr/src/app/dist ./dist
-
 # EXPOSE 3000
 
-# CMD ["dist/serverless.handler" ]
+# CMD ["dist/serverless.handler"]
+
+# DEVELOPMENT
+FROM amazon/aws-lambda-nodejs:18 As development
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+
+
+# PRODUCTION
+FROM amazon/aws-lambda-nodejs:18 As production
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm ci --only=production
+
+COPY . .
+
+COPY --from=development /usr/src/app/dist ./dist
+
+EXPOSE 3000
+
+CMD ["dist/serverless.handler" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,33 +10,47 @@
 
 # CMD ["dist/serverless.handler"]
 
-# DEVELOPMENT
-FROM amazon/aws-lambda-nodejs:18 As development
+
+
+###################
+# build for local development
+FROM public.ecr.aws/lambda/nodejs:18 As development
+
 WORKDIR /usr/src/app
 
-COPY package*.json ./
+COPY --chown=node:node package*.json ./
 
-RUN npm install
+RUN npm ci
 
-COPY . .
+COPY --chown=node:node . .
+
+USER node
+
+###################
+# BUILD FOR PRODUCTION
+FROM public.ecr.aws/lambda/nodejs:18 As build
+
+WORKDIR /usr/src/app
+
+COPY --chown=node:node package*.json ./
+COPY --chown=node:node --from=development /usr/src/app/node_modules ./node_modules
+COPY --chown=node:node . .
 
 RUN npm run build
 
+RUN npm ci --only=production && npm cache clean --force
+
+USER node
 
 
+
+###################
 # PRODUCTION
-FROM amazon/aws-lambda-nodejs:18 As production
+FROM public.ecr.aws/lambda/nodejs:18 As production
 
-WORKDIR /usr/src/app
-
-COPY package*.json ./
-
-RUN npm ci --only=production
-
-COPY . .
-
-COPY --from=development /usr/src/app/dist ./dist
+COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
+COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
 EXPOSE 3000
 
-CMD ["dist/serverless.handler" ]
+CMD [ "dist/serverless.handler" ]


### PR DESCRIPTION
- 전체적인 도커 이미지 크기를 줄였습니다.
- 실제 람다에서 정상 작동 테스트 하였습니다.
- main의 GitHub actions는 테스트 하지 않았습니다.)
   -> YAML파일의 수정이 없기 때문.

=========================
[로컬 Docker 기준]
기존 이미지 크기 : 1.18 GB
최적화 후 이미지 크기 : 909.2 MB

[ECR 기준]
기존 이미지 크기 : 350.76 MB
최적화 후 이미지 크기 : 227.28 MB (github actions를 통한 push에서 변동 있을 예정)