### PR TITLE
fix: Delete prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "prepare": "husky install",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",


### PR DESCRIPTION
문제 : Husky 추가 후, 배포하는 과정에서 docker build 가 터짐

원인 : npm ci --only=production 명령어에서 production 용만 설치함, 그러나 husky는 dev 용이기 때문에 설치를 안해서 script prepare 에서 문제가 생김

해결 : package.json에 prepare 스크립트 제거

