### PR TITLE
사전 예약 시간 설정 시 스케줄러 적용 추가

### DIFF
--- a/src/reservation/reservation-scheduler.ts
+++ b/src/reservation/reservation-scheduler.ts
@@ -3,6 +3,7 @@ import { Cron, SchedulerRegistry } from '@nestjs/schedule';
 import { addMonth, applyAsiaSeoulTz, getToday } from '@/util/date-util';
 import { PreReservationTransactionRepository } from './pre-reservation/pre-reservation.transaction.repository';
 import { OfficialReservationService } from './official-reservation/official-reservation.service';
+import { CronTime } from 'cron';
 
 @Injectable()
 export class ReservationScheduler {
@@ -14,32 +15,38 @@ export class ReservationScheduler {
     private schedulerRegistry: SchedulerRegistry,
   ) {}
 
-  @Cron('0 0 0 1 * *', {
+  @Cron('0 0 20 28-31 * *', {
     timeZone: 'Asia/Seoul',
     name: 'Create Pre Reservation Slot',
   })
   private async createPreReservationSlot() {
+    const now = new Date();
+    const lastDayOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+    if (now.getDate() !== lastDayOfMonth.getDate()) {
+      return;  // 오늘이 이 달의 마지막 날이 아니면 함수를 종료
+    }
+
     const today = getToday();
 
     const after1Month = addMonth(today, 1);
     const after2Month = addMonth(today, 2);
-
+    console.log("SCHEDULER is called : createPreReservationSlot");
     await this.preReservationTransactionRepo.updatePreReservation({
       isPre: false,
       thisMonth: after1Month,
       nextMonth: after2Month,
     });
+
+    await this.resetScheduleTime();
   }
 
-  // @Cron('0 0 0 1 * *', {
-  //   timeZone: 'Asia/Seoul',
-  //   name: 'Open Officail Reservation',
-  // })
-  @Cron('0 15 0 10 * *', {
+  @Cron('0 0 0 1 * *', {
     timeZone: 'Asia/Seoul',
-    name: 'Open Officail Reservation',
+    name: 'Open Official Reservation',
   })
   private async openOfficailReservation() {
+    console.log("SCHEDULER is called : openOfficialReservation");
     await this.officialReservationSvc.openReservation();
   }
 
@@ -60,5 +67,17 @@ export class ReservationScheduler {
     } catch (e) {
       return 'error: next fire date is in the past!';
     }
+  }
+
+  async updateScheduleTime(time: string) {
+    const job = this.schedulerRegistry.getCronJob('Create Pre Reservation Slot');
+    job.setTime(new CronTime(`${time} * *`, 'Asia/Seoul'));
+    job.start();
+  }
+
+  async resetScheduleTime() {
+    const job = this.schedulerRegistry.getCronJob('Create Pre Reservation Slot');
+    job.setTime(new CronTime(`0 0 20 28-31 * *`, 'Asia/Seoul'));
+    job.start();
   }
 }

--- a/src/reservation/reservation-scheduler.ts
+++ b/src/reservation/reservation-scheduler.ts
@@ -4,6 +4,7 @@ import { addMonth, applyAsiaSeoulTz, getToday } from '@/util/date-util';
 import { PreReservationTransactionRepository } from './pre-reservation/pre-reservation.transaction.repository';
 import { OfficialReservationService } from './official-reservation/official-reservation.service';
 import { CronTime } from 'cron';
+import dayjs from 'dayjs';
 
 @Injectable()
 export class ReservationScheduler {
@@ -20,11 +21,11 @@ export class ReservationScheduler {
     name: 'Create Pre Reservation Slot',
   })
   private async createPreReservationSlot() {
-    const now = new Date();
-    const lastDayOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-
-    if (now.getDate() !== lastDayOfMonth.getDate()) {
-      return;  // 오늘이 이 달의 마지막 날이 아니면 함수를 종료
+    const now = dayjs();
+    const lastDayOfMonth = now.daysInMonth();
+    
+    if (now.date() != lastDayOfMonth){
+      return; //이 달의 마지막 날이 아니면 종료
     }
 
     const today = getToday();


### PR DESCRIPTION
- 스케줄러 기본 값 : 매 달 마지막 날 20시.
 ⚠️이때 cron 라이브러리에서는 마지막 날을 의미하는 `L`을 지원하지 않아서 28일부터 31일까지 매일 돌면서 마지막 날인지 확인하고 돌아가도록 설정하였음. 다른 방법을 찾는다면..수정하겠습니다. ⚠️

- `/reservation/pre/time-setting` 호출 시, 스케줄러도 시간이 수정되게 구현함.
 수정한 값은 해당 달에만 적용되고, 그 시간이 지나면 다시 기본값으로 변경된다.