### PR TITLE
Hotfix: /:date 라우터 데코레이터 삭제

### DIFF
--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -51,7 +51,6 @@ export class ReservationController {
     name: 'date',
     description: '조회하고 싶은 날짜입니다.',
   })
-  @UseGuards(JwtAuthGuard)
   async getReservationInfo(
     @Param('date', getReservationPipe) date: string,
     @Query('state') state: string,


### PR DESCRIPTION
클라이언트 서비스 구현에 따라 관리자만 조회 가능하던 예약 현황 조회를 모두가 볼 수 있도록 guard를 삭제하였습니다.