### PR TITLE
Kum 17 관리자,사용자 구분 데코레이터 생성

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { JwtModule } from '@nestjs/jwt/dist';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Xe_Member_FutsalEntity } from '@/entites/xe_member.futsal.entity';
 import { CachesModule } from '@/cache/cache.module';
+import { Xe_Reservation_MemberEntity } from '@/entites/xe_reservation_member.entity';
 
 @Global()
 @Module({
@@ -15,6 +16,7 @@ import { CachesModule } from '@/cache/cache.module';
       secret: String(process.env.JWT_ACCESS_SECRET_KEY),
     }),
     TypeOrmModule.forFeature([Xe_Member_FutsalEntity]),
+    // TypeOrmModule.forFeature([Xe_Reservation_MemberEntity]),
     CachesModule,
   ],
   controllers: [AuthController],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { Repository } from 'typeorm';
 import { compare } from 'bcrypt';
 import { CacheService } from '@/cache/cache.service';
 import { Payload } from './jwt/jwt.payload';
+import { Xe_Reservation_MemberEntity } from '@/entites/xe_reservation_member.entity';
 
 @Injectable()
 export class AuthService {
@@ -26,6 +27,8 @@ export class AuthService {
     private cacheService: CacheService,
     @InjectRepository(Xe_Member_FutsalEntity)
     private userRepository: Repository<Xe_Member_FutsalEntity>,
+    // @InjectRepository(Xe_Reservation_MemberEntity)
+    // private userRepository: Repository<Xe_Reservation_MemberEntity>,
   ) {}
 
   //password 해시 생성 알고리즘 입니다 ! 후에 있을 실제 디비 연동을 위해 일단 주석처리 해놓았습니다.
@@ -45,12 +48,15 @@ export class AuthService {
     }
 
     const passwordCompareResult = await compare(userPassword, user.password);
+    // const passwordCompareResult = await compare(userPassword, user.user_password);
 
     if (!passwordCompareResult) {
       throw new NotFoundException(['잘못된 비밀번호 입니다.']);
     }
 
-    const payload = { userId: user.user_id, userName: user.user_name };
+    const payload = { userId: user.user_id, userName: user.user_name, permission: 'admin' };
+    // const payload = { userId: user.user_id, userName: user.user_name, permission: user.permission };
+    
     const accessToken = await this.generateAccessToken(payload);
     const refreshToken = await this.generateRefreshToken(payload);
     await this.storeRefreshTokenInCache(refreshToken, user.user_id);

--- a/src/auth/jwt/jwt.guard.ts
+++ b/src/auth/jwt/jwt.guard.ts
@@ -24,6 +24,7 @@ export class JwtAuthGuard implements CanActivate {
       req.user = {
         userId: payload.userId,
         userName: payload.userName,
+        permission: payload.permission
       };
       return true;
     } catch {

--- a/src/auth/jwt/jwt.payload.ts
+++ b/src/auth/jwt/jwt.payload.ts
@@ -2,4 +2,5 @@ export type Payload = {
   userId: string;
   sub: string;
   userName: string;
+  permission: string;
 };

--- a/src/common/decorators/permission.guard.ts
+++ b/src/common/decorators/permission.guard.ts
@@ -1,0 +1,35 @@
+import { CanActivate, ExecutionContext, Injectable, Type } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ModuleRef } from '@nestjs/core';
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  private permission: string ='';
+
+  constructor(private reflector: Reflector, private moduleRef: ModuleRef) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    console.log(user)
+    console.log(this.permission)
+    return user.permission === this.permission
+  }
+  
+  setPermissions(permission: string) {
+    this.permission = permission;
+  }
+}
+
+// Guard 생성을 위한 팩토리 함수
+export function CheckPermissions(permission: string): Type<CanActivate> {
+  @Injectable()
+  class MixinPermissionsGuard extends PermissionsGuard {
+    constructor(reflector: Reflector, moduleRef: ModuleRef) {
+      super(reflector, moduleRef);
+      this.setPermissions(permission);
+    }
+  }
+
+  return MixinPermissionsGuard;
+}

--- a/src/common/decorators/permission.guard.ts
+++ b/src/common/decorators/permission.guard.ts
@@ -3,7 +3,7 @@ import { Reflector } from '@nestjs/core';
 import { ModuleRef } from '@nestjs/core';
 
 @Injectable()
-export class PermissionsGuard implements CanActivate {
+export class PermissionGuard implements CanActivate {
   private permission: string ='';
 
   constructor(private reflector: Reflector, private moduleRef: ModuleRef) {}
@@ -22,9 +22,9 @@ export class PermissionsGuard implements CanActivate {
 }
 
 // Guard 생성을 위한 팩토리 함수
-export function CheckPermissions(permission: string): Type<CanActivate> {
+export function CheckPermission(permission: string): Type<CanActivate> {
   @Injectable()
-  class MixinPermissionsGuard extends PermissionsGuard {
+  class MixinPermissionsGuard extends PermissionGuard {
     constructor(reflector: Reflector, moduleRef: ModuleRef) {
       super(reflector, moduleRef);
       this.setPermissions(permission);

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -12,8 +12,9 @@ import { MembersService } from './members.service';
 import { JwtAuthGuard } from '@/auth/jwt/jwt.guard';
 import { MemberInfoDto } from '@/common/dto/members/members.dto';
 import { ParseIntPipe } from '@/pipe/parse-int.pipe';
+import { CheckPermissions } from '@/common/decorators/permission.guard';
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, CheckPermissions('admin'))
 @Controller('members')
 export class MembersController {
   constructor(private membersService: MembersService) {}

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -12,9 +12,9 @@ import { MembersService } from './members.service';
 import { JwtAuthGuard } from '@/auth/jwt/jwt.guard';
 import { MemberInfoDto } from '@/common/dto/members/members.dto';
 import { ParseIntPipe } from '@/pipe/parse-int.pipe';
-import { CheckPermissions } from '@/common/decorators/permission.guard';
+import { CheckPermission } from '@/common/decorators/permission.guard';
 
-@UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+@UseGuards(JwtAuthGuard, CheckPermission('admin'))
 @Controller('members')
 export class MembersController {
   constructor(private membersService: MembersService) {}

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -22,7 +22,7 @@ import { ReservationTimeService } from './time/reservation-time.service';
 import { BlockReservationDto } from '@/common/dto/reservation/block-reservation.dto';
 import { getReservationPipe } from '@/common/get-reservation.pipe';
 import { ReservationScheduler } from './reservation-scheduler';
-import { CheckPermissions } from '@/common/decorators/permission.guard';
+import { CheckPermission } from '@/common/decorators/permission.guard';
 
 @ApiTags('시설 예약')
 @Controller('reservation')
@@ -68,7 +68,7 @@ export class ReservationController {
     name: 'state',
     description: '사전 예약 활성화 상태입니다. (open = 시작, close = 중지)',
   })
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async reservationPreStart(@Query('state') state: string) {
     if (state === 'open') await this.reservationService.openReservation(false);
     else if (state === 'close')
@@ -83,7 +83,7 @@ export class ReservationController {
     description:
       '사전 예약 중단, 재개, 초기화 기능입니다. (stop = 중단, reopen = 재개, reset = 초기화)',
   })
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async preReservationStop(@Query('state') state: string) {
     if (state === 'stop') {
       await this.reservationService.stopPreReservation();
@@ -104,7 +104,7 @@ export class ReservationController {
     type: [PreReservationSetDto],
     description: '사전예약 시간을 설정하는 DTO입니다.',
   })
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async getPreReservationTimeInfo(@Body() body: PreReservationSetDto) {
     const { date, time, isPre } = body;
 
@@ -123,7 +123,7 @@ export class ReservationController {
     type: [PreReservationSetDto],
     description: '사전예약 시간을 설정하는 DTO입니다.',
   })
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async deletePreReservationList(@Body() body: PreReservationSetDto) {
     const { date, time, isPre } = body;
 
@@ -136,7 +136,7 @@ export class ReservationController {
 
   @Patch('/delete-month')
   @ApiOperation({ description: '해당 월 전체 예약 삭제' })
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async deleteMonthReservation(@Body() body: MonthReservationDeleteDto) {
     const { date, isPre } = body;
     if (isPre) {
@@ -150,7 +150,7 @@ export class ReservationController {
 
   @Patch('/delete-one')
   @ApiOperation({ description: '해당하는 날짜의 특정 시간대 예약 삭제' })
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async deleteOneReservation(@Body() body: OneReservationDeleteDto) {
     const { date, times, isPre } = body;
     if (isPre) {
@@ -171,7 +171,7 @@ export class ReservationController {
     name: 'state',
     description: '예약 활성화 상태입니다. (open = 시작, close = 중지)',
   })
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async reservationStart(@Query('state') state: string) {
     if (state === 'open')
       return await this.reservationService.openReservation(true);
@@ -181,7 +181,7 @@ export class ReservationController {
 
   @Post('/block')
   @HttpCode(200)
-  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
+  @UseGuards(JwtAuthGuard, CheckPermission('admin'))
   async blockRes(@Body() body: BlockReservationDto) {
     const { startDate, endDate } = body;
     return await this.reservationService.blockReservation(startDate, endDate);

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -22,6 +22,7 @@ import { ReservationTimeService } from './time/reservation-time.service';
 import { BlockReservationDto } from '@/common/dto/reservation/block-reservation.dto';
 import { getReservationPipe } from '@/common/get-reservation.pipe';
 import { ReservationScheduler } from './reservation-scheduler';
+import { CheckPermissions } from '@/common/decorators/permission.guard';
 
 @ApiTags('시설 예약')
 @Controller('reservation')
@@ -67,7 +68,7 @@ export class ReservationController {
     name: 'state',
     description: '사전 예약 활성화 상태입니다. (open = 시작, close = 중지)',
   })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async reservationPreStart(@Query('state') state: string) {
     if (state === 'open') await this.reservationService.openReservation(false);
     else if (state === 'close')
@@ -82,7 +83,7 @@ export class ReservationController {
     description:
       '사전 예약 중단, 재개, 초기화 기능입니다. (stop = 중단, reopen = 재개, reset = 초기화)',
   })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async preReservationStop(@Query('state') state: string) {
     if (state === 'stop') {
       await this.reservationService.stopPreReservation();
@@ -103,6 +104,7 @@ export class ReservationController {
     type: [PreReservationSetDto],
     description: '사전예약 시간을 설정하는 DTO입니다.',
   })
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async getPreReservationTimeInfo(@Body() body: PreReservationSetDto) {
     const { date, time, isPre } = body;
 
@@ -121,6 +123,7 @@ export class ReservationController {
     type: [PreReservationSetDto],
     description: '사전예약 시간을 설정하는 DTO입니다.',
   })
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async deletePreReservationList(@Body() body: PreReservationSetDto) {
     const { date, time, isPre } = body;
 
@@ -133,6 +136,7 @@ export class ReservationController {
 
   @Patch('/delete-month')
   @ApiOperation({ description: '해당 월 전체 예약 삭제' })
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async deleteMonthReservation(@Body() body: MonthReservationDeleteDto) {
     const { date, isPre } = body;
     if (isPre) {
@@ -146,7 +150,7 @@ export class ReservationController {
 
   @Patch('/delete-one')
   @ApiOperation({ description: '해당하는 날짜의 특정 시간대 예약 삭제' })
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async deleteOneReservation(@Body() body: OneReservationDeleteDto) {
     const { date, times, isPre } = body;
     if (isPre) {
@@ -167,6 +171,7 @@ export class ReservationController {
     name: 'state',
     description: '예약 활성화 상태입니다. (open = 시작, close = 중지)',
   })
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async reservationStart(@Query('state') state: string) {
     if (state === 'open')
       return await this.reservationService.openReservation(true);
@@ -176,6 +181,7 @@ export class ReservationController {
 
   @Post('/block')
   @HttpCode(200)
+  @UseGuards(JwtAuthGuard, CheckPermissions('admin'))
   async blockRes(@Body() body: BlockReservationDto) {
     const { startDate, endDate } = body;
     return await this.reservationService.blockReservation(startDate, endDate);


### PR DESCRIPTION
1. [CheckPermission]
- 사용자와 관리자 구분하는 데코레이터
- 입력값과 user의 permission을 대조한 값을 반환
- @UseGuards와 함께 사용
  사용 예 : `@UseGuards(CheckPermission('admin')`
- JWT Payload에 `permission` 추가

</br></br>

2.
- 관리자만 접근할 수 있는 곳에 가드 추가함
- reservation.controller.ts 일부
- members.controller.ts 일부

</br></br>

3.
- 현재 auth.service에서는 `Xe_Member_FutsalEntity`를 사용하고 있는데,
`Xe_Resrvation_MemberEntity`로 바꾸고 싶었으나, 비밀번호 이슈로 보류하였습니다.. (전환했을 때 비밀번호 불일치라고 떠요 ㅠㅠ)
관리자 계정 비밀번호를 수정하던지, 새롭게 추가하던지, 변경하던지.,,,등등,,, 이거 좀 확인 부탁드립니다.
그리고 추후에 수정하기 편하게 수정해야할 부분 아래 주석으로 달아뒀으니 주석 해제해서 사용하면 됩니다..람쥐..
- 사용할 주석 번호들:
  - auth.service.ts - 30,31,51,58
  - auth.module.ts - 19
  