### PR TITLE
Kum-22 유저정보crud

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -33,7 +33,7 @@ export class AuthController {
       .status(200)
       .header('access_token', `Bearer ${access_token}`)
       .header('refresh_token', `Bearer ${refresh_token}`)
-      .json({ message: ['로그인 성공'] });
+      .json({ message: '로그인 성공' });
   }
 
   @Get('/testToken')

--- a/src/common/dto/reservation/register-reservation.dto.ts
+++ b/src/common/dto/reservation/register-reservation.dto.ts
@@ -1,0 +1,33 @@
+import { IsNotEmpty, IsNumber, IsString, Matches, Validate, ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+
+
+@ValidatorConstraint({ name: 'ValidationNumberTypeOfTime', async: false })
+class ValidationNumberTypeOfTime implements ValidatorConstraintInterface {
+  validate(
+    value: number,
+    args: ValidationArguments,
+  ): boolean | Promise<boolean> {
+    if (value % 2 !== 0 || value > 20 || value < 8) { return false; }
+    return true;
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return '올바르지 않은 time 삽입을 시도함';
+  }
+}
+
+export class RegisterReservationDto {
+    @IsString()
+    @IsNotEmpty()
+    @Matches(/^(\d{4})-(\d{2})-(\d{2})$/, {
+        message:
+        ' 사전예약 date가 형식에 맞지 않습니다. xxxx-xx-xx 로 기입하여 주십시요.',
+    })
+    date: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  @Validate(ValidationNumberTypeOfTime)
+  time: number;
+
+}

--- a/src/common/dto/user/change-user.dto.ts
+++ b/src/common/dto/user/change-user.dto.ts
@@ -1,0 +1,16 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class ChangedUserInfo {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  sNumber: number;
+
+  @IsString()
+  @IsNotEmpty()
+  phoneNumber: string;
+
+}

--- a/src/entites/xe_reservation_member.entity.ts
+++ b/src/entites/xe_reservation_member.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn, Timestamp } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('xe_reservation_member')
 export class Xe_Reservation_MemberEntity {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -48,14 +48,15 @@ export class UserController {
   }
 
   
-  // @Delete('/reservation')
-  // @UseGuards(JwtAuthGuard, CheckPermission('user'))
-  // async deleteReservation(
-  //   @User() usser: User,
-  //   @Body() reservationTimeDto: RegisterReservationDto
-  // ){
-    
-  // }
+  @Delete('/reservation')
+  @UseGuards(JwtAuthGuard, CheckPermission('user'))
+  async deleteReservation(
+    @User() user: User,
+    @Body() reservationTimeDto: RegisterReservationDto
+  ){
+    const { userId } = user;
+    return await this.userService.deleteUserReservation(userId, reservationTimeDto);
+  }
 
   @Get('/test')
   @UseGuards(JwtAuthGuard, CheckPermission('user'))

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,9 +1,12 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Patch, Post, Put, UseGuards } from '@nestjs/common';
 import { UserService } from './user.service';
 import { JwtAuthGuard } from '@/auth/jwt/jwt.guard';
 import { User } from '@/common/decorators/user.decorator';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { NewUserDto } from '@/common/dto/user/make-user.dto';
+import { ChangedUserInfo } from '@/common/dto/user/change-user.dto';
+import { CheckPermission } from '@/common/decorators/permission.guard';
+import { RegisterReservationDto } from '@/common/dto/reservation/register-reservation.dto';
 
 @ApiTags('유저 정보 조회')
 @Controller('user')
@@ -16,11 +19,54 @@ export class UserController {
   async getUserInfo(@User() user: User) {
     const { userId } = user;
     return await this.userService.getUserInfo(userId);
-  }
+  } 
 
   @Post()
   async makeUser(@Body() info: NewUserDto){
     return await this.userService.makeNewUser(info);
   }
+
+  @Put()
+  @UseGuards(JwtAuthGuard)
+  async changeMyInfo(
+    @User() user: User,
+    @Body() changedInfo: ChangedUserInfo)
+  {
+    const { userId } = user;
+    return await this.userService.changeUserInfo(userId, changedInfo);
+  }
+
+  // 사용자 예약 예약 라우터
+  @Post('/reservation')
+  @UseGuards(JwtAuthGuard, CheckPermission('user'))
+  async registerReservation(
+    @User() user: User,
+    @Body() reservationTimeDto: RegisterReservationDto
+  ){
+    const { userId } = user;
+    return await this.userService.registerUserReservation(userId, reservationTimeDto)
+  }
+
+  
+  // @Delete('/reservation')
+  // @UseGuards(JwtAuthGuard, CheckPermission('user'))
+  // async deleteReservation(
+  //   @User() usser: User,
+  //   @Body() reservationTimeDto: RegisterReservationDto
+  // ){
+    
+  // }
+
+  @Get('/test')
+  @UseGuards(JwtAuthGuard, CheckPermission('user'))
+  async testRouter(
+    @User() user: User,
+    @Body() reservationTimeDto: RegisterReservationDto
+  ){
+    const { userId } = user;
+    return await this.userService.registerUserReservation(userId, reservationTimeDto)
+  }
+  
+
   
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -6,6 +6,11 @@ import { Xe_Member_FutsalEntity } from '@/entites/xe_member.futsal.entity';
 import { CachesModule } from '@/cache/cache.module';
 import { AuthModule } from '@/auth/auth.module';
 import { Xe_Reservation_MemberEntity } from '@/entites/xe_reservation_member.entity';
+import { Xe_Reservation_ConfigEntity } from '@/entites/xe_reservation_config.entity';
+import { Xe_ReservationEntity } from '@/entites/xe_reservation.entity';
+import { Xe_Reservation_PreEntity } from '@/entites/xe_reservation_pre.entity';
+import { Xe_Reservation_MajorEntity } from '@/entites/xe_reservation_major.entity';
+import { Xe_Reservation_CricleEntity } from '@/entites/xe_reservation_cricle.entity';
 
 @Module({
   imports: [
@@ -13,7 +18,11 @@ import { Xe_Reservation_MemberEntity } from '@/entites/xe_reservation_member.ent
     CachesModule,
     TypeOrmModule.forFeature([
       Xe_Reservation_MemberEntity,
-      Xe_Member_FutsalEntity
+      Xe_Reservation_ConfigEntity,
+      Xe_ReservationEntity,
+      Xe_Reservation_PreEntity,
+      Xe_Reservation_MajorEntity,
+      Xe_Reservation_CricleEntity
     ]),
   ],
   controllers: [UserController],

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,24 +1,66 @@
-import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Xe_Member_FutsalEntity } from '@/entites/xe_member.futsal.entity';
-import { Repository } from 'typeorm';
+import { BadRequestException, HttpException, HttpStatus, Injectable, NotFoundException, RequestTimeoutException, UnauthorizedException } from '@nestjs/common';
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import { NewUserDto } from '@/common/dto/user/make-user.dto';
 import { Xe_Reservation_MemberEntity } from '@/entites/xe_reservation_member.entity';
 import * as bcrypt from 'bcrypt';
+import { ChangedUserInfo } from '@/common/dto/user/change-user.dto';
+import { RegisterReservationDto } from '@/common/dto/reservation/register-reservation.dto';
+import { Xe_Reservation_ConfigEntity } from '@/entites/xe_reservation_config.entity';
+import { Xe_ReservationEntity } from '@/entites/xe_reservation.entity';
+import { Xe_Reservation_PreEntity } from '@/entites/xe_reservation_pre.entity';
+import { Xe_Reservation_CricleEntity } from '@/entites/xe_reservation_cricle.entity';
+import { Xe_Reservation_MajorEntity } from '@/entites/xe_reservation_major.entity';
 
 @Injectable()
 export class UserService {
   constructor(
-    @InjectRepository(Xe_Member_FutsalEntity)
-    private userRepository: Repository<Xe_Member_FutsalEntity>,
     @InjectRepository(Xe_Reservation_MemberEntity)
     private memberRepository: Repository<Xe_Reservation_MemberEntity>,
+    @InjectRepository(Xe_Reservation_ConfigEntity)
+    private configRepository: Repository<Xe_Reservation_ConfigEntity>,
+    @InjectRepository(Xe_Reservation_CricleEntity)
+    private circleRepository: Repository<Xe_Reservation_CricleEntity>,
+    @InjectRepository(Xe_Reservation_MajorEntity)
+    private majorRepository: Repository<Xe_Reservation_MajorEntity>,
+    @InjectRepository(Xe_ReservationEntity)
+    private officialReservationRepository: Repository<Xe_ReservationEntity>,
+    @InjectRepository(Xe_Reservation_PreEntity)
+    private preReservationRepository: Repository<Xe_Reservation_PreEntity>,
+    private dataSource: DataSource,
+    @InjectEntityManager()
+     private readonly entityManager: EntityManager
   ) {}
 
+  async findUserByUserId(userId: string)
+: Promise<Xe_Reservation_MemberEntity>
+{
+  const user = await this.memberRepository.findOne({
+    where: { user_id: userId },
+  });
+  if(!user){ throw new NotFoundException('해당 아이디의 유저가 존재하지 않습니다.')}
+  return user;
+}
+
+async findMemberSrlByUserId(userId: string)
+: Promise<number>
+{
+  const user = await this.memberRepository.findOne({
+    where: { user_id: userId },
+  });
+  if(!user){ throw new NotFoundException('해당 아이디의 유저가 존재하지 않습니다.')}
+  return user.member_srl;
+}
+
+async hashPassword(password:string):Promise<string>
+{
+  const saltRounds=parseInt(process.env.USER_HASH_COUNT); // 환경변수를 이용함, 가져올 때 문자로 변환되서 parseInt 넣어줌
+  const hashedPassword=await bcrypt.hash(password,saltRounds);
+  return hashedPassword;
+} 
+
   async getUserInfo(userId: string): Promise<any> {
-    const user = await this.userRepository.findOne({
-      where: { user_id: userId },
-    });
+    const user = await this.findUserByUserId(userId);
 
     if (!user) {
       throw new UnauthorizedException([
@@ -26,13 +68,11 @@ export class UserService {
       ]);
     }
 
-    const { password, ...userInfoWithoutPassword } = user;
+    const { member_srl, user_id, regdate, user_password, permission, ...userInfoWithoutPassword } = user;
     return userInfoWithoutPassword;
   }
 
-
   async makeNewUser(info: NewUserDto): Promise<string>{
-
     const existingUserById = await this.memberRepository.findOne({
       where: {user_id: info.id}
     })
@@ -66,14 +106,172 @@ export class UserService {
       throw new BadRequestException('알 수 없는 에러가 발생했습니다.')
     }
 }
-  async hashPassword(password:string):Promise<string>
+
+  async changeUserInfo(
+    userId: string, 
+    changedInfo: ChangedUserInfo
+  ): Promise<string>{
+    const { name, phoneNumber, sNumber } = changedInfo;
+
+    const user = await this.findUserByUserId(userId);
+    if (!user) {
+      throw new NotFoundException('해당 사용자가 존재하지 않습니다.');
+    }
+    user.user_name = name;
+    user.phone_number = phoneNumber;
+    user.user_student_number = sNumber;
+    await this.memberRepository.save(user);
+    return '수정 완료';  
+  }
+
+
+  async checkPreReservation()
+  :Promise<boolean>
   {
-    const saltRounds=parseInt(process.env.USER_HASH_COUNT); // 환경변수를 이용함, 가져올 때 문자로 변환되서 parseInt 넣어줌
-    const hashedPassword=await bcrypt.hash(password,saltRounds);
-    return hashedPassword;
-  } 
+    const configKey = await this.configRepository.findOne({ where: { key: 'is_pre_reservation_period'}});
+    if(!configKey){ throw new NotFoundException('에러가 발생했습니다.') }
+    if(configKey.value === 'N'){ return false; }
+    else if( configKey.value === 'Y'){ return true; }
+    throw new BadRequestException('알 수 없는 에러가 발생했습니다');
+  }
 
+  async checkAvailabilityOfReservation()
+  :Promise<boolean>
+  {
+    const configKey = await this.configRepository.findOne({ where: { key: 'is_able'}});
+    if(!configKey){ throw new NotFoundException('에러가 발생했습니다.') }
+    if(configKey.value === 'Y'){ return true; }
+    else if( configKey.value === 'N'){ return false; }
+    throw new BadRequestException('알 수 없는 에러가 발생했습니다');
+  }
 
+  async registerPreReservation(
+    userId: string, 
+    reservationDate: string, 
+    reservationTime: number
+  ){
+    console.log("register Pre Res");
+    console.log(userId, reservationDate, reservationTime);
 
+    const user = await this.findUserByUserId(userId);
+
+    const targetReservationSlot = await this.preReservationRepository.findOne({
+      where: {date: reservationDate, time: reservationTime}
+    });
+
+    if(!targetReservationSlot){
+     throw new NotFoundException('해당 예약 시간대가 없습니다. ');
+    }
+    if(targetReservationSlot.delete_date){ 
+      throw new NotFoundException( '해당 내역은 존재하지 않습니다.' )
+    }
+    if(targetReservationSlot.is_able === 'N'){
+      throw new BadRequestException('예약이 가능하지 않습니다.');
+    }
+    if(targetReservationSlot.member_srl){
+       throw new BadRequestException('해당 시간은 이미 예약되었습니다.');
+      }
+
+    targetReservationSlot.member_srl = user.member_srl;
+    targetReservationSlot.place_srl = 0;
+    targetReservationSlot.circle = (await this.circleRepository.findOne({ where: { circle_srl: user.circle_srl } })).circle_name;
+    console.log(targetReservationSlot.circle)
+    targetReservationSlot.major = (await this.majorRepository.findOne({ where: { major_srl: user.major_srl } })).major_name;
+    console.log(targetReservationSlot.major)
+    await this.preReservationRepository.save(targetReservationSlot);  
+    return reservationDate + " " + reservationTime + " 예약 완료";
+  }
   
+
+  async registerOfficalReservation(
+    userId: string, 
+    reservationDate: string, 
+    reservationTime: number
+){
+    const user = await this.findUserByUserId(userId);
+  
+    console.log(user);
+    const targetReservationSlot = await this.officialReservationRepository.findOne({
+        where: {
+            date: reservationDate, 
+            time: reservationTime
+        },
+        lock: { mode: "pessimistic_write" }
+    });
+
+    if(!targetReservationSlot){
+        throw new NotFoundException('해당 예약 시간대가 없습니다. ');
+    }
+    if(targetReservationSlot.is_able === 'N'){
+        throw new BadRequestException('해당 시간대의 예약은 불가능합니다.');
+    }
+    if(targetReservationSlot.member_srl){
+        throw new BadRequestException('해당 시간은 이미 예약되었습니다.');
+    }
+
+    try{
+        targetReservationSlot.member_srl = user.major_srl;
+        targetReservationSlot.place_srl = 0;
+        targetReservationSlot.circle = (await this.circleRepository.findOne({ where: { circle_srl: user.circle_srl } })).circle_name;
+        targetReservationSlot.major = (await this.majorRepository.findOne({ where: { major_srl: user.major_srl } })).major_name;
+        await this.officialReservationRepository.save(targetReservationSlot);  
+        return reservationDate + reservationTime + "예약 완료";
+    }catch(error){
+        throw new RequestTimeoutException(error);
+    }
+}
+
+
+  async registerUserReservation(
+    userId: string,
+    reservationInfo: RegisterReservationDto
+  ){
+    const isPre = await this.checkPreReservation();
+    const { date, time } = reservationInfo; 
+
+    if(!await this.checkAvailabilityOfReservation()){
+       throw new BadRequestException("현재 예약이 중지된 상태입니다.") 
+    }
+
+    if(isPre){
+      return await this.registerPreReservation(userId, date, time);
+    }
+    else if(!isPre){
+      return await this.registerOfficalReservation(userId, date, time);
+    }
+
+    throw new BadRequestException("알 수 없는 오류가 발생했습니다.");
+  }
+
+
+  async deleteUserReservation(
+    userId: string,
+    reservationInfo: RegisterReservationDto
+  ){
+    const checkPreRes = await this.checkPreReservation();
+    const { date, time } = reservationInfo;
+    if(checkPreRes){
+      return await this.deletePreReservation(userId, date, time);
+    }
+    else if(!checkPreRes){
+      return await this.deleteOfficalReservation(userId, date, time);
+    }
+    throw new BadRequestException('올바르지 않은 요청입니다. ');
+  }
+
+ async deletePreReservation(
+  userId: string, 
+  reservationDate: string, 
+  reservationTime: number
+  ){
+
+  }
+
+  async deleteOfficalReservation(
+    userId: string, 
+    reservationDate: string, 
+    reservationTime: number
+  ){
+
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -146,12 +146,12 @@ async hashPassword(password:string):Promise<string>
     throw new BadRequestException('알 수 없는 에러가 발생했습니다');
   }
 
-  
-    async registerPreReservation(
-      userInfo: Xe_Reservation_MemberEntity,
-      reservationDate: string,
-      reservationTime: number,
-    ) {
+  async registerPreReservation(
+    userInfo: Xe_Reservation_MemberEntity,
+    reservationDate: string,
+    reservationTime: number,
+  ) {
+    try{
       return await this.connection.transaction(async (manager) => {
         const targetReservationSlot = await manager.findOne(Xe_Reservation_PreEntity, {
           where: { date: reservationDate, time: reservationTime },
@@ -180,7 +180,10 @@ async hashPassword(password:string):Promise<string>
   
         return reservationDate + " " + reservationTime + " 예약 완료";
       });
+    }catch(error){
+      throw new BadRequestException('error');
     }
+  }
   
 
   async registerOfficalReservation(
@@ -188,6 +191,7 @@ async hashPassword(password:string):Promise<string>
     reservationDate: string, 
     reservationTime: number
 ){
+  try{
     return await this.connection.transaction(async (manager) => {
       const targetReservationSlot = await manager.findOne(Xe_ReservationEntity, {
         where: { date: reservationDate, time: reservationTime },
@@ -207,11 +211,13 @@ async hashPassword(password:string):Promise<string>
       targetReservationSlot.circle = (await manager.findOne(Xe_Reservation_CricleEntity, { where: { circle_srl: userInfo.circle_srl } })).circle_name;
       targetReservationSlot.major = (await manager.findOne(Xe_Reservation_MajorEntity, { where: { major_srl: userInfo.major_srl } })).major_name;
       await manager.save(targetReservationSlot);
-      return reservationDate + " " + reservationTime + " 예약 완료";
+      return reservationDate + " " + reservationTime + "일 예약 완료";
     });
-}
-
-
+    }catch(error){
+      throw new BadRequestException(error);
+    }
+  }
+   
   async registerUserReservation(
     userId: string,
     reservationInfo: RegisterReservationDto
@@ -237,7 +243,6 @@ async hashPassword(password:string):Promise<string>
 
     throw new BadRequestException("알 수 없는 오류가 발생했습니다.");
   }
-
 
   async deleteUserReservation(
     userId: string,
@@ -312,5 +317,5 @@ async hashPassword(password:string):Promise<string>
       throw new BadRequestException(error);
     }
    }
-
+   
 }


### PR DESCRIPTION


# 유저 정보 crud 및 예약 create - delete 구현
+ register-reservaiton-dto, change-user-dto 생성(request body json을 서버에서 효율적으로 처리하기 위함)


### 현재 구현 완료 feature
+ 본인 유저정보 조회, 생성, 수정
+ 사용자 예약하기, 삭제하기

## 중요! 예약하기
+ 예약 시간 시작 되자마자 수십명 되는 유저들이 우다다 광클을 함
+ 따라서 예약이 덮어지는 경우가 발생할 수 있으므로 트랜잭션 락을 추가함
+ 다만 registerPreReservation, registerOfficialReservation method를 실행 할 때 디비에 쿼리를 총 7번을 질의하기에(....) 튜닝이 필요해 보입니다.