### PR TITLE
fix: password && sNumber validation

### DIFF
--- a/src/auth/dto/create-user.dto.ts
+++ b/src/auth/dto/create-user.dto.ts
@@ -33,7 +33,6 @@ export class CreateUserDto {
   @ApiProperty()
   user_id: string;
 
-  @Validate(NotContainsValueConstraint)
   @IsString()
   @Matches(/^(?=.*[a-zA-Z])(?=.*[!@#$%^&*])(?=.*[0-9])\S{8,20}$/, {
     message:

--- a/src/common/dto/user/make-user.dto.ts
+++ b/src/common/dto/user/make-user.dto.ts
@@ -1,5 +1,21 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsNumber, IsString, Matches } from 'class-validator';
+import { registerDecorator, ValidationOptions, ValidationArguments, IsNotEmpty, IsNumber, IsString, Matches, Max, Min } from 'class-validator';
+
+export function IsEightDigits(validationOptions?: ValidationOptions) {
+  return function (object: any, propertyName: string) {
+    registerDecorator({
+      name: 'isEightDigits',
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [],
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          return typeof value === 'number' && value >= 10000000 && value <= 99999999;
+        },
+      },
+    });
+  };
+}
 
 export class NewUserDto {
   @IsString()
@@ -8,6 +24,9 @@ export class NewUserDto {
 
   @IsNumber()
   @IsNotEmpty()
+  @IsEightDigits(
+    { message: '학번은 8자리로 입력해야 합니다' }
+  )
   sNumber: number;
 
   @IsString()


### PR DESCRIPTION
1. password에 id의 string이 포함될 수 있게 기존에 존재하던 NotContainsValueConstraint validation을 삭제하였습니다.
2. sNumber가 8자리 숫자만 가능하도록 IsEightDigits validation을 추가하였습니다.